### PR TITLE
Vpd 991 clean up logging

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -20,9 +20,7 @@
 
     <logger name="application" level="DEBUG"/>
 
-    <logger name="connector" level="TRACE">
-        <appender-ref ref="STDOUT"/>
-    </logger>
+    <logger name="connector" level="TRACE"/>
 
     <root level="INFO">
         <appender-ref ref="FILE"/>


### PR DESCRIPTION
Correct the file name for the log file used during local development. Also remove the unused appender.