### PR TITLE
Vpd 1779 refactor tests

### DIFF
--- a/test-utils/data/TestData.scala
+++ b/test-utils/data/TestData.scala
@@ -260,40 +260,31 @@ trait TestData {
     )
   }
 
-
   // Synonyms for obligations in terms of returns
-  def returns(returns: Seq[ObligationDetails]) = obligations(returns)
+  def returns(returns: Seq[ObligationDetails]): Seq[ObligationItem] = obligations(returns)
   def completedReturn(periodKey: PeriodKey): ObligationDetails = fulfilledObligation(periodKey)
   def outstandingReturn(periodKey: PeriodKey): ObligationDetails = openObligation(periodKey)
 
   def obligations(obligations: Seq[ObligationDetails]): Seq[ObligationItem] = {
-    obligations.map(od =>
+    obligations.map(obligationDetails =>
       ObligationItem(
         identification = None,
-        obligationDetails = od)
+        obligationDetails = obligationDetails)
     )
   }
-  def fulfilledObligation(periodKey: PeriodKey): ObligationDetails = buildObligationDetails(periodKey, ObligationStatus.F)
-  def openObligation(periodKey: PeriodKey): ObligationDetails = buildObligationDetails(periodKey, ObligationStatus.O)
+  def fulfilledObligation(periodKey: PeriodKey): ObligationDetails = obligationDetails(periodKey, ObligationStatus.F)
+  def openObligation(periodKey: PeriodKey): ObligationDetails      = obligationDetails(periodKey, ObligationStatus.O)
 
-  private def buildObligationItem(periodKey: PeriodKey,
-                                  obligationStatus: ObligationStatus) = {
-    ObligationItem(
-      identification = None,
-      obligationDetails = buildObligationDetails(periodKey, obligationStatus)
-    )
-  }
-
-  private def buildObligationDetails(periodKey: PeriodKey,
-                                     obligationStatus: ObligationStatus,
-                                     submittedOnTime: Boolean = false) = {
+  private def obligationDetails(periodKey: PeriodKey,
+                                obligationStatus: ObligationStatus,
+                                submittedOnTime: Boolean = false) = {
     ObligationDetails(
       openOrFulfilledStatus = obligationStatus.toString,
-      iCFromDate = firstDayOf(periodKey),
-      iCToDate = lastDayOf(periodKey),
-      iCDateReceived = dateReceived(periodKey, obligationStatus, submittedOnTime),
-      iCDueDate = dueDate(periodKey),
-      periodKey = periodKey.value
+      iCFromDate            = firstDayOf(periodKey),
+      iCToDate              = lastDayOf(periodKey),
+      iCDateReceived        = dateReceived(periodKey, obligationStatus, submittedOnTime),
+      iCDueDate             = dueDate(periodKey),
+      periodKey             = periodKey.value
     )
   }
 

--- a/test-utils/data/TestData.scala
+++ b/test-utils/data/TestData.scala
@@ -238,6 +238,7 @@ trait TestData {
   )
 
   def createMockObligationsResponse(): ObligationsResponse = {
+    // Hmm... we need to do something about managing the time during tests.
     val currentDate = LocalDate.now()
 
     val october2027 = PeriodKey("27AJ")
@@ -247,45 +248,44 @@ trait TestData {
     ObligationsResponse(
       obligation = Seq(
         // Outstanding return - Due
-        ObligationItem(
-          identification = None,
-          obligationDetails = ObligationDetails(
-            openOrFulfilledStatus = ObligationStatus.O.toString,
-            iCFromDate = firstDayOf(december2027),
-            iCToDate = lastDayOf(december2027),
-            iCDateReceived = None,
-            iCDueDate = dueDate(december2027),
-            periodKey = december2027.value
-          )
-        ),
+        outstandingReturn(december2027),
         // Outstanding return - Overdue
-        ObligationItem(
-          identification = None,
-          obligationDetails = ObligationDetails(
-            openOrFulfilledStatus = ObligationStatus.O.toString,
-            iCFromDate = firstDayOf(november2027),
-            iCToDate = lastDayOf(november2027),
-            iCDateReceived = None,
-            iCDueDate = dueDate(november2027),
-            periodKey = november2027.value
-          )
-        ),
+        outstandingReturn(november2027),
         // Completed return
-        ObligationItem(
-          identification = None,
-          obligationDetails = ObligationDetails(
-            openOrFulfilledStatus = ObligationStatus.F.toString,
-            iCFromDate = firstDayOf(october2027),
-            iCToDate = lastDayOf(october2027),
-            iCDateReceived = receivedAfterDueDate(october2027),
-            iCDueDate = dueDate(october2027),
-            periodKey = october2027.value
-          )
-        )
+        completedReturn(october2027)
       )
     )
   }
 
+  private def completedReturn(periodKey: PeriodKey) = {
+    val obligationStatus = ObligationStatus.F
+    ObligationItem(
+      identification = None,
+      obligationDetails = ObligationDetails(
+        openOrFulfilledStatus = obligationStatus.toString,
+        iCFromDate = firstDayOf(periodKey),
+        iCToDate = lastDayOf(periodKey),
+        iCDateReceived = receivedAfterDueDate(periodKey),
+        iCDueDate = dueDate(periodKey),
+        periodKey = periodKey.value
+      )
+    )
+  }
+
+  private def outstandingReturn(periodKey: PeriodKey) = {
+    val obligationStatus = ObligationStatus.O
+    ObligationItem(
+      identification = None,
+      obligationDetails = ObligationDetails(
+        openOrFulfilledStatus = obligationStatus.toString,
+        iCFromDate = firstDayOf(periodKey),
+        iCToDate = lastDayOf(periodKey),
+        iCDateReceived = None,
+        iCDueDate = dueDate(periodKey),
+        periodKey = periodKey.value
+      )
+    )
+  }
 
   def firstDayOf(periodKey: PeriodKey) = LocalDate.of(year(periodKey), month(periodKey), 1)
   def lastDayOf(periodKey: PeriodKey)  = firstDayOf(periodKey).plusMonths(1).minusDays(1)

--- a/test-utils/data/TestData.scala
+++ b/test-utils/data/TestData.scala
@@ -258,41 +258,39 @@ trait TestData {
   }
 
   private def completedReturn(periodKey: PeriodKey) = {
-    val obligationStatus = ObligationStatus.F
-    ObligationItem(
-      identification = None,
-      obligationDetails = ObligationDetails(
-        openOrFulfilledStatus = obligationStatus.toString,
-        iCFromDate = firstDayOf(periodKey),
-        iCToDate = lastDayOf(periodKey),
-        iCDateReceived = receivedAfterDueDate(periodKey),
-        iCDueDate = dueDate(periodKey),
-        periodKey = periodKey.value
-      )
-    )
+    buildObligationItem(periodKey, ObligationStatus.F)
   }
 
   private def outstandingReturn(periodKey: PeriodKey) = {
-    val obligationStatus = ObligationStatus.O
+    buildObligationItem(periodKey, ObligationStatus.O)
+  }
+
+  private def buildObligationItem(periodKey: PeriodKey,
+                                  obligationStatus: ObligationStatus) = {
     ObligationItem(
       identification = None,
       obligationDetails = ObligationDetails(
         openOrFulfilledStatus = obligationStatus.toString,
         iCFromDate = firstDayOf(periodKey),
         iCToDate = lastDayOf(periodKey),
-        iCDateReceived = None,
+        iCDateReceived = dateReceived(periodKey, obligationStatus),
         iCDueDate = dueDate(periodKey),
         periodKey = periodKey.value
       )
     )
   }
 
-  def firstDayOf(periodKey: PeriodKey) = LocalDate.of(year(periodKey), month(periodKey), 1)
-  def lastDayOf(periodKey: PeriodKey)  = firstDayOf(periodKey).plusMonths(1).minusDays(1)
-  def dueDate(periodKey: PeriodKey)    = firstDayOf(periodKey).plusMonths(1).plusDays(6)
+  private def firstDayOf(periodKey: PeriodKey) = LocalDate.of(year(periodKey), month(periodKey), 1)
+  private def lastDayOf(periodKey: PeriodKey)  = firstDayOf(periodKey).plusMonths(1).minusDays(1)
+  private def dueDate(periodKey: PeriodKey)    = firstDayOf(periodKey).plusMonths(1).plusDays(6)
 
-  def receivedBeforeDueDate(october2027: PeriodKey) = Some(dueDate(october2027).minusDays(1))
-  def receivedAfterDueDate(october2027: PeriodKey)  = Some(dueDate(october2027).plusDays(1))
+  private def dateReceived(periodKey: PeriodKey, obligationStatus: ObligationStatus) =
+    obligationStatus match {
+      case ObligationStatus.F => Some(receivedAfterDueDate(periodKey))
+      case ObligationStatus.O => None
+  }
+  private def receivedBeforeDueDate(october2027: PeriodKey) = dueDate(october2027).minusDays(1)
+  private def receivedAfterDueDate(october2027: PeriodKey)  = dueDate(october2027).plusDays(1)
 
   def month(periodKey: PeriodKey): Int = (periodKey.value.last - 'A') + 1
   def year(periodKey: PeriodKey): Int = ("20" + periodKey.value.take(2)).toInt

--- a/test-utils/data/TestData.scala
+++ b/test-utils/data/TestData.scala
@@ -237,23 +237,24 @@ trait TestData {
     testDeclarationDetails
   )
 
-  def createMockObligationsResponse(): ObligationsResponse = {
-    // Hmm... we need to do something about managing the time during tests.
-    val currentDate = LocalDate.now()
+  val october2027 = PeriodKey("27AJ")
+  val november2027 = PeriodKey("27AK")
+  val december2027 = PeriodKey("27AL")
 
-    val october2027 = PeriodKey("27AJ")
-    val november2027 = PeriodKey("27AK")
-    val december2027 = PeriodKey("27AL")
-    
+  def createMockObligationsResponse(): ObligationsResponse = {
     ObligationsResponse(
-      obligation = Seq(
-        // Outstanding return - Due
-        outstandingReturn(december2027),
-        // Outstanding return - Overdue
-        outstandingReturn(november2027),
-        // Completed return
-        completedReturn(october2027)
-      )
+      obligation = createMockObligations()
+    )
+  }
+
+  def createMockObligations(): Seq[ObligationItem] = {
+    Seq(
+      // Outstanding return - Due
+      outstandingReturn(december2027),
+      // Outstanding return - Overdue
+      outstandingReturn(november2027),
+      // Completed return
+      completedReturn(october2027)
     )
   }
 
@@ -269,14 +270,18 @@ trait TestData {
                                   obligationStatus: ObligationStatus) = {
     ObligationItem(
       identification = None,
-      obligationDetails = ObligationDetails(
-        openOrFulfilledStatus = obligationStatus.toString,
-        iCFromDate = firstDayOf(periodKey),
-        iCToDate = lastDayOf(periodKey),
-        iCDateReceived = dateReceived(periodKey, obligationStatus),
-        iCDueDate = dueDate(periodKey),
-        periodKey = periodKey.value
-      )
+      obligationDetails = buildObligationDetails(periodKey, obligationStatus)
+    )
+  }
+
+  private def buildObligationDetails(periodKey: PeriodKey, obligationStatus: ObligationStatus) = {
+    ObligationDetails(
+      openOrFulfilledStatus = obligationStatus.toString,
+      iCFromDate = firstDayOf(periodKey),
+      iCToDate = lastDayOf(periodKey),
+      iCDateReceived = dateReceived(periodKey, obligationStatus),
+      iCDueDate = dueDate(periodKey),
+      periodKey = periodKey.value
     )
   }
 

--- a/test-utils/data/TestData.scala
+++ b/test-utils/data/TestData.scala
@@ -240,6 +240,10 @@ trait TestData {
   def createMockObligationsResponse(): ObligationsResponse = {
     val currentDate = LocalDate.now()
 
+    val october2027 = PeriodKey("27AJ")
+    val november2027 = PeriodKey("27AK")
+    val december2027 = PeriodKey("27AL")
+    
     ObligationsResponse(
       obligation = Seq(
         // Outstanding return - Due
@@ -247,11 +251,11 @@ trait TestData {
           identification = None,
           obligationDetails = ObligationDetails(
             openOrFulfilledStatus = ObligationStatus.O.toString,
-            iCFromDate = LocalDate.of(2027, 12, 1),
-            iCToDate = LocalDate.of(2027, 12, 31),
+            iCFromDate = firstDayOf(december2027),
+            iCToDate = lastDayOf(december2027),
             iCDateReceived = None,
-            iCDueDate = LocalDate.of(2028, 1, 7),
-            periodKey = "27AL"
+            iCDueDate = dueDate(december2027),
+            periodKey = december2027.value
           )
         ),
         // Outstanding return - Overdue
@@ -259,28 +263,39 @@ trait TestData {
           identification = None,
           obligationDetails = ObligationDetails(
             openOrFulfilledStatus = ObligationStatus.O.toString,
-            iCFromDate = LocalDate.of(2027, 11, 1),
-            iCToDate = LocalDate.of(2027, 11, 30),
+            iCFromDate = firstDayOf(november2027),
+            iCToDate = lastDayOf(november2027),
             iCDateReceived = None,
-            iCDueDate = currentDate.minusDays(5),
-            periodKey = "27AK"
+            iCDueDate = dueDate(november2027),
+            periodKey = november2027.value
           )
         ),
         // Completed return
         ObligationItem(
           identification = None,
           obligationDetails = ObligationDetails(
-            openOrFulfilledStatus = "F",
-            iCFromDate = LocalDate.of(2027, 10, 1),
-            iCToDate = LocalDate.of(2027, 10, 31),
-            iCDateReceived = Some(LocalDate.of(2027, 11, 15)),
-            iCDueDate = LocalDate.of(2027, 11, 30),
-            periodKey = "27AJ"
+            openOrFulfilledStatus = ObligationStatus.F.toString,
+            iCFromDate = firstDayOf(october2027),
+            iCToDate = lastDayOf(october2027),
+            iCDateReceived = receivedAfterDueDate(october2027),
+            iCDueDate = dueDate(october2027),
+            periodKey = october2027.value
           )
         )
       )
     )
   }
+
+
+  def firstDayOf(periodKey: PeriodKey) = LocalDate.of(year(periodKey), month(periodKey), 1)
+  def lastDayOf(periodKey: PeriodKey)  = firstDayOf(periodKey).plusMonths(1).minusDays(1)
+  def dueDate(periodKey: PeriodKey)    = firstDayOf(periodKey).plusMonths(1).plusDays(6)
+
+  def receivedBeforeDueDate(october2027: PeriodKey) = Some(dueDate(october2027).minusDays(1))
+  def receivedAfterDueDate(october2027: PeriodKey)  = Some(dueDate(october2027).plusDays(1))
+
+  def month(periodKey: PeriodKey): Int = (periodKey.value.last - 'A') + 1
+  def year(periodKey: PeriodKey): Int = ("20" + periodKey.value.take(2)).toInt
 
   def createReturnDisplayResponse(): ReturnDisplayResponse = {
     ReturnDisplayResponse(

--- a/test-utils/data/TestData.scala
+++ b/test-utils/data/TestData.scala
@@ -250,21 +250,24 @@ trait TestData {
   def createMockObligations(): Seq[ObligationItem] = {
     Seq(
       // Outstanding return - Due
-      outstandingReturn(december2027),
+      openObligation(december2027),
       // Outstanding return - Overdue
-      outstandingReturn(november2027),
+      openObligation(november2027),
       // Completed return
-      completedReturn(october2027)
+      fulfilledObligation(october2027)
+    ).map(od =>     ObligationItem(
+      identification = None,
+      obligationDetails = od
+    )
     )
   }
 
-  private def completedReturn(periodKey: PeriodKey) = {
-    buildObligationItem(periodKey, ObligationStatus.F)
-  }
+  // Synonyms for obligations in terms of returns
+  def completedReturn(periodKey: PeriodKey): ObligationDetails = fulfilledObligation(periodKey)
+  def outstandingReturn(periodKey: PeriodKey): ObligationDetails = openObligation(periodKey)
 
-  private def outstandingReturn(periodKey: PeriodKey) = {
-    buildObligationItem(periodKey, ObligationStatus.O)
-  }
+  def fulfilledObligation(periodKey: PeriodKey): ObligationDetails = buildObligationDetails(periodKey, ObligationStatus.F)
+  def openObligation(periodKey: PeriodKey): ObligationDetails = buildObligationDetails(periodKey, ObligationStatus.O)
 
   private def buildObligationItem(periodKey: PeriodKey,
                                   obligationStatus: ObligationStatus) = {

--- a/test-utils/data/TestData.scala
+++ b/test-utils/data/TestData.scala
@@ -274,12 +274,14 @@ trait TestData {
     )
   }
 
-  private def buildObligationDetails(periodKey: PeriodKey, obligationStatus: ObligationStatus) = {
+  private def buildObligationDetails(periodKey: PeriodKey,
+                                     obligationStatus: ObligationStatus,
+                                     submittedOnTime: Boolean = false) = {
     ObligationDetails(
       openOrFulfilledStatus = obligationStatus.toString,
       iCFromDate = firstDayOf(periodKey),
       iCToDate = lastDayOf(periodKey),
-      iCDateReceived = dateReceived(periodKey, obligationStatus),
+      iCDateReceived = dateReceived(periodKey, obligationStatus, submittedOnTime),
       iCDueDate = dueDate(periodKey),
       periodKey = periodKey.value
     )
@@ -289,9 +291,15 @@ trait TestData {
   private def lastDayOf(periodKey: PeriodKey)  = firstDayOf(periodKey).plusMonths(1).minusDays(1)
   private def dueDate(periodKey: PeriodKey)    = firstDayOf(periodKey).plusMonths(1).plusDays(6)
 
-  private def dateReceived(periodKey: PeriodKey, obligationStatus: ObligationStatus) =
+  private def dateReceived(periodKey: PeriodKey,
+                           obligationStatus: ObligationStatus,
+                           submittedOnTime: Boolean) =
     obligationStatus match {
-      case ObligationStatus.F => Some(receivedAfterDueDate(periodKey))
+      case ObligationStatus.F => Some(
+        submittedOnTime match {
+          case true  => receivedBeforeDueDate(periodKey)
+          case false => receivedAfterDueDate(periodKey)
+          })
       case ObligationStatus.O => None
   }
   private def receivedBeforeDueDate(october2027: PeriodKey) = dueDate(october2027).minusDays(1)

--- a/test-utils/data/TestData.scala
+++ b/test-utils/data/TestData.scala
@@ -248,24 +248,31 @@ trait TestData {
   }
 
   def createMockObligations(): Seq[ObligationItem] = {
-    Seq(
-      // Outstanding return - Due
-      openObligation(december2027),
-      // Outstanding return - Overdue
-      openObligation(november2027),
-      // Completed return
-      fulfilledObligation(october2027)
-    ).map(od =>     ObligationItem(
-      identification = None,
-      obligationDetails = od
-    )
+    obligations(
+      Seq(
+        // Outstanding return - Due
+        openObligation(december2027),
+        // Outstanding return - Overdue
+        openObligation(november2027),
+        // Completed return
+        fulfilledObligation(october2027)
+      )
     )
   }
 
+
   // Synonyms for obligations in terms of returns
+  def returns(returns: Seq[ObligationDetails]) = obligations(returns)
   def completedReturn(periodKey: PeriodKey): ObligationDetails = fulfilledObligation(periodKey)
   def outstandingReturn(periodKey: PeriodKey): ObligationDetails = openObligation(periodKey)
 
+  def obligations(obligations: Seq[ObligationDetails]): Seq[ObligationItem] = {
+    obligations.map(od =>
+      ObligationItem(
+        identification = None,
+        obligationDetails = od)
+    )
+  }
   def fulfilledObligation(periodKey: PeriodKey): ObligationDetails = buildObligationDetails(periodKey, ObligationStatus.F)
   def openObligation(periodKey: PeriodKey): ObligationDetails = buildObligationDetails(periodKey, ObligationStatus.O)
 

--- a/test/controllers/returns/submit/ConfirmationControllerSpec.scala
+++ b/test/controllers/returns/submit/ConfirmationControllerSpec.scala
@@ -36,8 +36,6 @@ class ConfirmationControllerSpec extends SpecBase {
 
   "ConfirmationController" - {
 
-    val viewReturnUrl = s"${controllers.returns.view.routes.ViewIndividualReturnController.onPageLoad(periodKey).url}"
-
     "must return OK and the correct view for a GET" in {
 
       val mockSubscriptionConnector = mock[SubscriptionConnector]
@@ -50,6 +48,7 @@ class ConfirmationControllerSpec extends SpecBase {
 
       running(application) {
 
+        val viewReturnUrl = s"${controllers.returns.view.routes.ViewIndividualReturnController.onPageLoad(periodKey).url}"
 
         val contactPreference = SubscriptionContactPreferences(true, Option(emailAddress))
 

--- a/test/controllers/returns/view/ViewIndividualReturnControllerSpec.scala
+++ b/test/controllers/returns/view/ViewIndividualReturnControllerSpec.scala
@@ -50,7 +50,7 @@ class ViewIndividualReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        val request = FakeRequest(GET, returns.view.routes.ViewIndividualReturnController.onPageLoad(periodKey).url)
+        val request = FakeRequest(GET, routes.ViewIndividualReturnController.onPageLoad(periodKey).url)
 
         val result = route(application, request).value
 
@@ -87,7 +87,7 @@ class ViewIndividualReturnControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        val request = FakeRequest(GET, returns.view.routes.ViewIndividualReturnController.onPageLoad(periodKey).url)
+        val request = FakeRequest(GET, routes.ViewIndividualReturnController.onPageLoad(periodKey).url)
 
         val result = route(application, request).value
 

--- a/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
+++ b/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
@@ -41,7 +41,7 @@ class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
     )
 
     "when user has fulfilled returns" - {
-      val vm = BeforeYouStartViewModel(obligationsWithFulfilled, october2027).get
+      val vm = BeforeYouStartViewModel(obligationsWithFulfilled, november2027).get
 
       "return the correct year of the return" in {
         vm.yearOfReturn mustBe 2027
@@ -52,11 +52,11 @@ class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
       }
 
       "return the correct month due" in {
-        vm.dueDate mustBe "7 November"
+        vm.dueDate mustBe "7 December"
       }
 
       "return the correct return period month" in {
-        vm.returnPeriod mustBe "October"
+        vm.returnPeriod mustBe "November"
       }
 
       "return Eligible for adjustmentsEligibility" in {

--- a/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
+++ b/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
@@ -18,29 +18,23 @@ package viewmodels.returns
 
 import base.{SpecBase, UnitSpec}
 import models.identifiers.PeriodKey
-import models.obligations.{ObligationDetails, ObligationItem, ObligationStatus}
+import models.obligations.ObligationDetails
 import models.returns.AdjustmentsEligibility
 import viewmodels.returns.submit.BeforeYouStartViewModel
-
-import java.time.LocalDate
 
 
 class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
   
   "BeforeYouStartViewModel" - {
-    val obligationsWithFulfilled = obligations(
-      Seq(
-        openObligation(december2027),
-        openObligation(november2027),
-        fulfilledObligation(october2027)
-      )
-    )
-
-    val obligationsWithoutFulfilled = obligations(
-      Seq(openObligation(december2027))
-    )
 
     "when user has fulfilled returns" - {
+      val obligationsWithFulfilled = obligations(
+        Seq(
+          openObligation(december2027),
+          openObligation(november2027),
+          fulfilledObligation(october2027)
+        )
+      )
       val vm = BeforeYouStartViewModel(obligationsWithFulfilled, november2027).get
 
       "return the correct year of the return" in {
@@ -65,6 +59,9 @@ class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
     }
 
     "when user has no fulfilled returns" - {
+      val obligationsWithoutFulfilled = obligations(
+        Seq(openObligation(december2027))
+      )
       val vm = BeforeYouStartViewModel(obligationsWithoutFulfilled, december2027).get
 
       "return the correct month due" in {
@@ -84,7 +81,10 @@ class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
       val nonExistentPeriodKey = PeriodKey("99ZZ")
 
       "return None" in {
-        val result = BeforeYouStartViewModel(obligationsWithFulfilled, nonExistentPeriodKey)
+        val anyOldObligations = obligations(
+          Seq(openObligation(december2027))
+        )
+        val result = BeforeYouStartViewModel(anyOldObligations, nonExistentPeriodKey)
         
         result mustBe None
       }

--- a/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
+++ b/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
@@ -22,19 +22,14 @@ import models.obligations.{ObligationDetails, ObligationItem, ObligationStatus}
 import models.returns.AdjustmentsEligibility
 import viewmodels.returns.submit.BeforeYouStartViewModel
 
-import java.time.{LocalDate, Month}
-import java.time.format.TextStyle
-import java.util.Locale
+import java.time.LocalDate
 
 
 class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
   
   "BeforeYouStartViewModel" - {
-    val testPeriodKeyOctober = PeriodKey("27AJ")
-    val testMonthOctober = Month.OCTOBER
-
-    val testPeriodKeyDecember = PeriodKey("27AL")
-    val testMonthDecember = Month.DECEMBER
+    val october2027 = PeriodKey("27AJ")
+    val december2027 = PeriodKey("27AL")
 
     val obligationsWithFulfilled = createMockObligationsResponse().obligation
 
@@ -47,42 +42,28 @@ class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
           iCToDate = LocalDate.of(2027, 12, 31),
           iCDateReceived = None,
           iCDueDate = LocalDate.of(2028, 1, 7),
-          periodKey = testPeriodKeyDecember.toString
+          periodKey = december2027.toString
         )
       )
     )
 
     "when user has fulfilled returns" - {
-      val vm = BeforeYouStartViewModel(obligationsWithFulfilled, testPeriodKeyOctober).get
+      val vm = BeforeYouStartViewModel(obligationsWithFulfilled, october2027).get
 
       "return the correct year of the return" in {
-        val expectedResult = obligationsWithFulfilled
-          .find(_.obligationDetails.periodKey == testPeriodKeyOctober.toString)
-          .map(_.obligationDetails.iCFromDate.getYear)
-          .getOrElse(fail("Test setup error: October obligation not found"))
-
-        vm.yearOfReturn mustBe expectedResult
+        vm.yearOfReturn mustBe 2027
       }
 
       "return the correct year the return is due" in {
-        val expectedResult = obligationsWithFulfilled
-          .find(_.obligationDetails.periodKey == testPeriodKeyOctober.toString)
-          .map(_.obligationDetails.iCDueDate.getYear)
-          .getOrElse(fail("Test setup error: October obligation not found"))
-
-        vm.dueYear mustBe expectedResult
+        vm.dueYear mustBe 2027
       }
 
       "return the correct month due" in {
-        val expectedResult = s"30 ${testMonthOctober.plus(1).getDisplayName(TextStyle.FULL, Locale.UK)}"
-
-        vm.dueDate mustBe expectedResult
+        vm.dueDate mustBe "30 November"
       }
 
       "return the correct return period month" in {
-        val expectedResult = testMonthOctober.getDisplayName(TextStyle.FULL, Locale.UK)
-
-        vm.returnPeriod mustBe expectedResult
+        vm.returnPeriod mustBe "October"
       }
 
       "return Eligible for adjustmentsEligibility" in {
@@ -91,18 +72,14 @@ class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
     }
 
     "when user has no fulfilled returns" - {
-      val vm = BeforeYouStartViewModel(obligationsWithoutFulfilled, testPeriodKeyDecember).get
+      val vm = BeforeYouStartViewModel(obligationsWithoutFulfilled, december2027).get
 
       "return the correct month due" in {
-        val expectedResult = s"7 ${testMonthDecember.plus(1).getDisplayName(TextStyle.FULL, Locale.UK)}"
-
-        vm.dueDate mustBe expectedResult
+        vm.dueDate mustBe "7 January"
       }
 
       "return the correct return period month" in {
-        val expectedResult = testMonthDecember.getDisplayName(TextStyle.FULL, Locale.UK)
-
-        vm.returnPeriod mustBe expectedResult
+        vm.returnPeriod mustBe "December"
       }
 
       "return NotEligible for adjustmentsEligibility" in {

--- a/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
+++ b/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
@@ -59,7 +59,7 @@ class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
       }
 
       "return the correct month due" in {
-        vm.dueDate mustBe "30 November"
+        vm.dueDate mustBe "7 November"
       }
 
       "return the correct return period month" in {

--- a/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
+++ b/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
@@ -28,23 +28,16 @@ import java.time.LocalDate
 class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
   
   "BeforeYouStartViewModel" - {
-    val october2027 = PeriodKey("27AJ")
-    val december2027 = PeriodKey("27AL")
-
-    val obligationsWithFulfilled = createMockObligations()
-
-    val obligationsWithoutFulfilled = Seq(
-      ObligationItem(
-        identification = None,
-        obligationDetails = ObligationDetails(
-          openOrFulfilledStatus = ObligationStatus.O.toString,
-          iCFromDate = LocalDate.of(2027, 12, 1),
-          iCToDate = LocalDate.of(2027, 12, 31),
-          iCDateReceived = None,
-          iCDueDate = LocalDate.of(2028, 1, 7),
-          periodKey = december2027.toString
-        )
+    val obligationsWithFulfilled = obligations(
+      Seq(
+        openObligation(december2027),
+        openObligation(november2027),
+        fulfilledObligation(october2027)
       )
+    )
+
+    val obligationsWithoutFulfilled = obligations(
+      Seq(openObligation(december2027))
     )
 
     "when user has fulfilled returns" - {

--- a/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
+++ b/test/viewmodels/returns/BeforeYouStartViewModelSpec.scala
@@ -31,7 +31,7 @@ class BeforeYouStartViewModelSpec extends SpecBase with UnitSpec {
     val october2027 = PeriodKey("27AJ")
     val december2027 = PeriodKey("27AL")
 
-    val obligationsWithFulfilled = createMockObligationsResponse().obligation
+    val obligationsWithFulfilled = createMockObligations()
 
     val obligationsWithoutFulfilled = Seq(
       ObligationItem(


### PR DESCRIPTION
Introduce easier building of obligations in tests

Work from BeforeYouStatViewModelSpec making the tests more direct and introducing obligation builders to reduce the amount of code in the tests and be more flexible. Fixed up a few issues that became evident along the way.

This has only been applied in 1 test, and could be rolled out over more tests given time.