### PR TITLE
VPD-1775 duty rate per10ml

### DIFF
--- a/app/config/DutyRateConfig.scala
+++ b/app/config/DutyRateConfig.scala
@@ -39,7 +39,7 @@ def parseRatesFromConfig(configuration: Configuration): Seq[DutyRate] = {
         start = LocalDate.parse(rateConfig.get[String]("start-date")),
         end   = LocalDate.parse(rateConfig.get[String]("end-date"))
       ),
-      ratePencePerMl = Integer.parseInt(rateConfig.get[String]("rate-pence-per-ml"))
+      ratePencePerMl = Integer.parseInt(rateConfig.get[String]("rate-pence-per-10ml"))
     )
   }.sortBy(_.period.start)
 }

--- a/app/config/DutyRateConfig.scala
+++ b/app/config/DutyRateConfig.scala
@@ -39,7 +39,7 @@ def parseRatesFromConfig(configuration: Configuration): Seq[DutyRate] = {
         start = LocalDate.parse(rateConfig.get[String]("start-date")),
         end   = LocalDate.parse(rateConfig.get[String]("end-date"))
       ),
-      ratePencePerMl = Integer.parseInt(rateConfig.get[String]("rate-pence-per-10ml"))
+      ratePencePer10Ml = Integer.parseInt(rateConfig.get[String]("rate-pence-per-10ml"))
     )
   }.sortBy(_.period.start)
 }

--- a/app/config/DutyRateValidator.scala
+++ b/app/config/DutyRateValidator.scala
@@ -30,7 +30,7 @@ class DutyRateValidator @Inject()(clock: Clock) {
 
   def validatePositiveRates(rates: Seq[DutyRate]): Either[List[DutyRateValidationError], Seq[DutyRate]] = {
     val invalidRates = rates.collect {
-      case rate if rate.ratePencePerMl <= 0 => NegativeRate(rate)
+      case rate if rate.ratePencePer10Ml <= 0 => NegativeRate(rate)
     }
     invalidRates match {
       case Nil    => Right(rates)

--- a/app/controllers/returns/submit/CheckYourAnswersController.scala
+++ b/app/controllers/returns/submit/CheckYourAnswersController.scala
@@ -44,8 +44,8 @@ class CheckYourAnswersController @Inject()(
   def onPageLoad: Action[AnyContent] = (identify andThen returnsEnabled andThen getData andThen requireData).async { implicit request =>
     val pk = request.periodKey
     
-    dutyRateService.getDutyRate(request.enrolmentVpdId, pk).map { dutyRate =>
-      Ok(view(pk, CheckYourAnswersViewModel(request.userAnswers, dutyRate, pk, returnsDateUtils)))
+    dutyRateService.getDutyRateInPoundsPerMl(request.enrolmentVpdId, pk).map { dutyRateInPoundsPerMl =>
+      Ok(view(pk, CheckYourAnswersViewModel(request.userAnswers, dutyRateInPoundsPerMl, pk, returnsDateUtils)))
     }
   }
 

--- a/app/controllers/returns/submit/DeclareDutyCheckAnswersController.scala
+++ b/app/controllers/returns/submit/DeclareDutyCheckAnswersController.scala
@@ -42,8 +42,8 @@ class DeclareDutyCheckAnswersController @Inject()(
   def onPageLoad: Action[AnyContent] = (identify andThen returnsEnabled andThen getData andThen requireData).async { implicit request =>
     val pk = request.periodKey
     
-    dutyRateService.getDutyRate(request.enrolmentVpdId, pk).map { dutyRate =>
-      DeclareDutyCheckAnswersViewModel(request.userAnswers, dutyRate, pk) match {
+    dutyRateService.getDutyRateInPoundsPerMl(request.enrolmentVpdId, pk).map { dutyRateInPoundsPerMl =>
+      DeclareDutyCheckAnswersViewModel(request.userAnswers, dutyRateInPoundsPerMl, pk) match {
         case Some(vm) => Ok(view(pk, vm))
         case None     => Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
       }

--- a/app/controllers/returns/submit/adjustments/AdjustmentVolumeWithTypeController.scala
+++ b/app/controllers/returns/submit/adjustments/AdjustmentVolumeWithTypeController.scala
@@ -21,7 +21,7 @@ import controllers.actions.returns.{ReturnsDataRequiredAction, ReturnsDataRetrie
 import controllers.returns.PeriodKeyExtraction
 import forms.returns.adjustments.{AdjustmentVolumeWithTypeFormData, AdjustmentVolumeWithTypeFormProvider}
 import models.returns.adjustments.{AdjustmentEntry, AdjustmentList, AdjustmentType}
-import models.{Mode, NormalMode}
+import models.Mode
 import navigation.ReturnsNavigator
 import pages.returns.adjustments.AdjustmentListPage
 import play.api.data.Form

--- a/app/forms/returns/EnterDutyAmountFormProvider.scala
+++ b/app/forms/returns/EnterDutyAmountFormProvider.scala
@@ -33,8 +33,8 @@ class EnterDutyAmountFormProvider @Inject()(
   def apply(periodKey: PeriodKey, vpdId: VpdId)
            (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Form[BigDecimal]] = {
 
-    dutyRateService.getDutyRate(vpdId, periodKey).map { dutyRate =>
-      val dutyRateInPencePerMl = (dutyRate * 100).toInt
+    dutyRateService.getDutyRateInPoundsPerMl(vpdId, periodKey).map { dutyRateInPoundsPerMl =>
+      val dutyRateInPencePerMl = (dutyRateInPoundsPerMl * 100).toInt
       val maxVolumeResult = volumePrecisionService.calculateMaxVolume(dutyRateInPencePerMl)
 
       Form(

--- a/app/forms/returns/EnterDutySuspenseFormProvider.scala
+++ b/app/forms/returns/EnterDutySuspenseFormProvider.scala
@@ -38,8 +38,8 @@ class EnterDutySuspenseFormProvider @Inject()(
   def apply(periodKey: PeriodKey, vpdId: VpdId)
            (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Form[DutySuspenseVolumes]] = {
 
-    dutyRateService.getDutyRate(vpdId, periodKey).map { dutyRate =>
-      val dutyRateInPencePerMl = (dutyRate * 100).toInt
+    dutyRateService.getDutyRateInPoundsPerMl(vpdId, periodKey).map { dutyRateInPoundsPer10ml =>
+      val dutyRateInPencePerMl = (dutyRateInPoundsPer10ml * 100).toInt
       val maxVolumeResult = volumePrecisionService.calculateMaxVolume(dutyRateInPencePerMl)
 
       Form(

--- a/app/forms/returns/SpoiltVolumeByPeriodFormProvider.scala
+++ b/app/forms/returns/SpoiltVolumeByPeriodFormProvider.scala
@@ -33,8 +33,8 @@ class SpoiltVolumeByPeriodFormProvider @Inject()(
   def apply(periodKey: PeriodKey, vpdId: VpdId)
            (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Form[BigDecimal]] = {
 
-    dutyRateService.getDutyRate(vpdId, periodKey).map { dutyRate =>
-      val dutyRateInPencePerMl = (dutyRate * 100).toInt
+    dutyRateService.getDutyRateInPoundsPerMl(vpdId, periodKey).map { dutyRateInPoundsPer10Ml =>
+      val dutyRateInPencePerMl = (dutyRateInPoundsPer10Ml * 100).toInt
       val maxVolumeResult = volumePrecisionService.calculateMaxVolume(dutyRateInPencePerMl)
 
       Form(

--- a/app/models/returns/DutyRate.scala
+++ b/app/models/returns/DutyRate.scala
@@ -22,7 +22,7 @@ import java.time.LocalDate
 
 final case class DutyRate(
                            period: DateRange,
-                           ratePencePerMl: Int
+                           ratePencePer10Ml: Int
                          ) {
 
   def isValidFor(date: LocalDate): Boolean = period.contains(date)

--- a/app/models/returns/DutyRateValidationError.scala
+++ b/app/models/returns/DutyRateValidationError.scala
@@ -29,7 +29,7 @@ object DutyRateValidationError {
   }
 
   final case class NegativeRate(rate: DutyRate) extends DutyRateValidationError {
-    val message: String = s"Duty rate must be positive: ${rate.ratePencePerMl}"
+    val message: String = s"Duty rate must be positive: ${rate.ratePencePer10Ml}"
   }
 
   final case class InvalidDateRange(rate: DutyRate) extends DutyRateValidationError {

--- a/app/services/returns/AdjustmentCheckYourAnswersService.scala
+++ b/app/services/returns/AdjustmentCheckYourAnswersService.scala
@@ -65,8 +65,10 @@ class AdjustmentCheckYourAnswersService @Inject()(
     uniquePeriods.map { period =>
       val obligation = obligationDetails.find(_.periodKey == period.toString)
       val dutyRate = obligation.map { obl =>
-        val rateInPencePerMl = dutyRateService.getRateForDate(obl.iCFromDate)
-        BigDecimal(rateInPencePerMl) / 100
+        val rateInPencePer10Ml = dutyRateService.getRateForDateInPencePer10ml(obl.iCFromDate)
+        val rateInPencePerMl = BigDecimal(rateInPencePer10Ml) / 10
+        val dutyRateInPoundsPerMl = rateInPencePerMl / 100
+        dutyRateInPoundsPerMl
       }.getOrElse(
         // scalafix:off DisableSyntax.throw
         throw new RuntimeException(s"No obligation found for period ${period.toString}")

--- a/app/services/returns/BuildReturnSubmissionService.scala
+++ b/app/services/returns/BuildReturnSubmissionService.scala
@@ -52,7 +52,7 @@ class BuildReturnSubmissionService @Inject()(
     val overDeclaration = buildOverDeclaration(ua, periodKeyToDutyRateInPencePerMl)
     val otherOptions = buildOtherOptions(ua)
 
-    val spoiltProduct = buildSpoiltProduct(ua, vpdId, periodKeyToDutyRateInPencePerMl)
+    val spoiltProduct = buildSpoiltProduct(ua, periodKeyToDutyRateInPencePerMl)
 
     val totalDutyDue = totalDutyDueCalculationService.calculate(
       totalDutyDueVapingProducts,
@@ -186,7 +186,7 @@ class BuildReturnSubmissionService @Inject()(
     )
   }
 
-  private def buildSpoiltProduct(ua: ReturnsUserAnswers, vpdId: VpdId, periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]): Option[SpoiltProduct] = {
+  private def buildSpoiltProduct(ua: ReturnsUserAnswers, periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]) = {
     val declareSpoiltProducts = ua.get(DeclareSpoiltProductsPage)
     val spoiltVolumes = ua.get(SpoiltVolumeByPeriodPage)
 

--- a/app/services/returns/BuildReturnSubmissionService.scala
+++ b/app/services/returns/BuildReturnSubmissionService.scala
@@ -41,18 +41,18 @@ class BuildReturnSubmissionService @Inject()(
   def buildSubmission(ua: ReturnsUserAnswers,
                       obligation: ObligationDetails,
                       vpdId: VpdId,
-                      periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]): ReturnCreateRequest = {
+                      periodKeyToDutyRateInPencePer10Ml: Map[PeriodKey, Int]): ReturnCreateRequest = {
 
     val periodKey = PeriodKey(ua.periodKey)
 
-    val vapingProductsProduced = buildVapingProductsProduced(ua, obligation, periodKeyToDutyRateInPencePerMl)
+    val vapingProductsProduced = buildVapingProductsProduced(ua, obligation, periodKeyToDutyRateInPencePer10Ml)
     val totalDutyDueVapingProducts = vapingProductsProduced.returns.headOption.map(_.dutyDue).getOrElse(ZERO_VALUE)
 
-    val underDeclaration = buildUnderDeclaration(ua, periodKeyToDutyRateInPencePerMl)
-    val overDeclaration = buildOverDeclaration(ua, periodKeyToDutyRateInPencePerMl)
+    val underDeclaration = buildUnderDeclaration(ua, periodKeyToDutyRateInPencePer10Ml)
+    val overDeclaration = buildOverDeclaration(ua, periodKeyToDutyRateInPencePer10Ml)
     val otherOptions = buildOtherOptions(ua)
 
-    val spoiltProduct = buildSpoiltProduct(ua, periodKeyToDutyRateInPencePerMl)
+    val spoiltProduct = buildSpoiltProduct(ua, periodKeyToDutyRateInPencePer10Ml)
 
     val totalDutyDue = totalDutyDueCalculationService.calculate(
       totalDutyDueVapingProducts,
@@ -80,17 +80,17 @@ class BuildReturnSubmissionService @Inject()(
 
   private def buildVapingProductsProduced(ua: ReturnsUserAnswers,
                                           obligation: ObligationDetails,
-                                          periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]): VapingProductsProduced = {
+                                          periodKeyToDutyRateInPencePer10Ml: Map[PeriodKey, Int]): VapingProductsProduced = {
     val dutyDeclared = ua.get(DeclareDutyPage).getOrElse(false)
     val liquidInMl = ua.get(EnterDutyAmountPage).getOrElse(ZERO_VALUE)
 
-    val dutyRateInPencePerMl: Int = periodKeyToDutyRateInPencePerMl(PeriodKey(obligation.periodKey))
+    val dutyRateInPencePerMl = BigDecimal(periodKeyToDutyRateInPencePer10Ml(PeriodKey(obligation.periodKey))) / 10
 
     val liquidInLitres = ConvertToLitres(liquidInMl).toLitres
 
-    val dutyDue = (liquidInMl * (BigDecimal(dutyRateInPencePerMl) / 100)).setScale(2, BigDecimal.RoundingMode.DOWN)
+    val dutyDue = (liquidInMl * (dutyRateInPencePerMl / 100)).setScale(2, BigDecimal.RoundingMode.DOWN)
 
-    val dutyRateInPoundsPer10Ml = (BigDecimal(dutyRateInPencePerMl) / 100) * 10
+    val dutyRateInPoundsPer10Ml = (dutyRateInPencePerMl / 100) * 10
 
     val vapingProductsProduced = if (dutyDeclared) {
       VapingProductsProduced(vapingProdManufactured = FLAG_FILLED, returns = Seq(
@@ -106,13 +106,13 @@ class BuildReturnSubmissionService @Inject()(
     vapingProductsProduced
   }
 
-  private def buildUnderDeclaration(ua: ReturnsUserAnswers, periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]): Option[UnderDeclaration] = {
+  private def buildUnderDeclaration(ua: ReturnsUserAnswers, periodKeyToDutyRateInPencePer10Ml: Map[PeriodKey, Int]): Option[UnderDeclaration] = {
     val underDeclaredEntries = ua.get(AdjustmentListPage)
       .map(_.adjustments.filter(_.adjustmentType == AdjustmentType.UnderDeclared))
       .getOrElse(Seq.empty)
 
     if (underDeclaredEntries.nonEmpty) {
-      val underDeclarationProducts = underDeclaredEntries.map(buildUnderDeclarationProduct(_, periodKeyToDutyRateInPencePerMl))
+      val underDeclarationProducts = underDeclaredEntries.map(buildUnderDeclarationProduct(_, periodKeyToDutyRateInPencePer10Ml))
       val reasonForUnderDecl = if (underDeclarationProducts.map(_.dutyDue).sum >= AdjustmentType.dutyThreshold)
         ua.get(AdjustmentReasonPage)
       else
@@ -132,10 +132,10 @@ class BuildReturnSubmissionService @Inject()(
     }
   }
 
-  private def buildUnderDeclarationProduct(entry: AdjustmentEntry, periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]): UnderDeclarationProduct = {
-    val dutyRateInPencePerMl = periodKeyToDutyRateInPencePerMl(entry.period)
-    val dutyRateInPoundsPer10Ml = (BigDecimal(dutyRateInPencePerMl) * 10) / 100
-    val dutyDue = (entry.volumeInMl * (BigDecimal(dutyRateInPencePerMl) / 100)).setScale(2, BigDecimal.RoundingMode.DOWN)
+  private def buildUnderDeclarationProduct(entry: AdjustmentEntry, periodKeyToDutyRateInPencePer10Ml: Map[PeriodKey, Int]): UnderDeclarationProduct = {
+    val dutyRateInPencePerMl = BigDecimal(periodKeyToDutyRateInPencePer10Ml(entry.period)) / 10
+    val dutyRateInPoundsPer10Ml = (dutyRateInPencePerMl * 10) / 100
+    val dutyDue = (entry.volumeInMl * (dutyRateInPencePerMl / 100)).setScale(2, BigDecimal.RoundingMode.DOWN)
 
     UnderDeclarationProduct(
       returnPeriodAffected = entry.period.toString,
@@ -146,13 +146,13 @@ class BuildReturnSubmissionService @Inject()(
     )
   }
 
-  private def buildOverDeclaration(ua: ReturnsUserAnswers, periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]): Option[OverDeclaration] = {
+  private def buildOverDeclaration(ua: ReturnsUserAnswers, periodKeyToDutyRateInPencePer10Ml: Map[PeriodKey, Int]): Option[OverDeclaration] = {
     val overDeclaredEntries = ua.get(AdjustmentListPage)
       .map(_.adjustments.filter(_.adjustmentType == AdjustmentType.OverDeclared))
       .getOrElse(Seq.empty)
 
     if (overDeclaredEntries.nonEmpty) {
-      val overDeclarationProducts = overDeclaredEntries.map(buildOverDeclarationProduct(_, periodKeyToDutyRateInPencePerMl))
+      val overDeclarationProducts = overDeclaredEntries.map(buildOverDeclarationProduct(_, periodKeyToDutyRateInPencePer10Ml))
       val reasonForOverDecl = if (overDeclarationProducts.map(_.dutyDue).sum >= AdjustmentType.dutyThreshold)
         ua.get(AdjustmentReasonPage)
       else
@@ -172,10 +172,10 @@ class BuildReturnSubmissionService @Inject()(
     }
   }
 
-  private def buildOverDeclarationProduct(entry: AdjustmentEntry, periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]): OverDeclarationProduct = {
-    val dutyRateInPencePerMl = periodKeyToDutyRateInPencePerMl(entry.period)
-    val dutyRateInPoundsPer10Ml = (BigDecimal(dutyRateInPencePerMl) * 10) / 100
-    val dutyDue = (entry.volumeInMl * (BigDecimal(dutyRateInPencePerMl) / 100)).setScale(2, BigDecimal.RoundingMode.DOWN)
+  private def buildOverDeclarationProduct(entry: AdjustmentEntry, periodKeyToDutyRateInPencePer10Ml: Map[PeriodKey, Int]): OverDeclarationProduct = {
+    val dutyRateInPencePerMl = BigDecimal(periodKeyToDutyRateInPencePer10Ml(entry.period)) / 10
+    val dutyRateInPoundsPer10Ml = (dutyRateInPencePerMl * 10) / 100
+    val dutyDue = (entry.volumeInMl * (dutyRateInPencePerMl / 100)).setScale(2, BigDecimal.RoundingMode.DOWN)
 
     OverDeclarationProduct(
       returnPeriodAffected = entry.period.toString,
@@ -186,13 +186,13 @@ class BuildReturnSubmissionService @Inject()(
     )
   }
 
-  private def buildSpoiltProduct(ua: ReturnsUserAnswers, periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]) = {
+  private def buildSpoiltProduct(ua: ReturnsUserAnswers, periodKeyToDutyRateInPencePer10Ml: Map[PeriodKey, Int]) = {
     val declareSpoiltProducts = ua.get(DeclareSpoiltProductsPage)
     val spoiltVolumes = ua.get(SpoiltVolumeByPeriodPage)
 
     (declareSpoiltProducts, spoiltVolumes) match {
       case (Some(true), Some(volumes)) if volumes.nonEmpty =>
-        val spoiltProducts = volumes.map(buildSpoiltProductItem(_, periodKeyToDutyRateInPencePerMl))
+        val spoiltProducts = volumes.map(buildSpoiltProductItem(_, periodKeyToDutyRateInPencePer10Ml))
 
         Some(SpoiltProduct(
           spoiltProductFilled = FLAG_FILLED,
@@ -210,12 +210,12 @@ class BuildReturnSubmissionService @Inject()(
     }
   }
 
-  private def buildSpoiltProductItem(spoiltVolume: SpoiltVolumeByPeriod, periodKeyToDutyRateInPencePerMl: Map[PeriodKey, Int]) = {
-    val dutyRateInPencePerMl = periodKeyToDutyRateInPencePerMl(spoiltVolume.periodKey)
-    val dutyRateInPoundsPer10Ml = (BigDecimal(dutyRateInPencePerMl) * 10) / 100
+  private def buildSpoiltProductItem(spoiltVolume: SpoiltVolumeByPeriod, periodKeyToDutyRateInPencePer10Ml: Map[PeriodKey, Int]) = {
+    val dutyRateInPencePerMl = BigDecimal(periodKeyToDutyRateInPencePer10Ml(spoiltVolume.periodKey)) / 10
+    val dutyRateInPoundsPer10Ml = (dutyRateInPencePerMl * 10) / 100
     val volumeInMl = spoiltVolume.volume
     val volumeInLitres = ConvertToLitres(volumeInMl).toLitres
-    val dutyDue = (volumeInMl * (BigDecimal(dutyRateInPencePerMl) / 100)).setScale(2, BigDecimal.RoundingMode.DOWN)
+    val dutyDue = (volumeInMl * (dutyRateInPencePerMl / 100)).setScale(2, BigDecimal.RoundingMode.DOWN)
 
     SpoiltProductItem(
       returnPeriodAffected = spoiltVolume.periodKey.toString,

--- a/app/services/returns/DutyRateService.scala
+++ b/app/services/returns/DutyRateService.scala
@@ -31,7 +31,7 @@ class DutyRateService @Inject()(dutyRateConfig: DutyRateConfig, obligationServic
   def getRateForDate(date: LocalDate): Int =
     dutyRateConfig.rates
       .find(_.isValidFor(date))
-      .map(_.ratePencePerMl)
+      .map(_.ratePencePer10Ml)
       .get  // Safe because validation ensures there's always a rate
 
 

--- a/app/services/returns/DutyRateService.scala
+++ b/app/services/returns/DutyRateService.scala
@@ -28,33 +28,33 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class DutyRateService @Inject()(dutyRateConfig: DutyRateConfig, obligationService: ObligationService) {
   
-  def getRateForDate(date: LocalDate): Int =
+  def getRateForDateInPencePer10ml(date: LocalDate): Int =
     dutyRateConfig.rates
       .find(_.isValidFor(date))
       .map(_.ratePencePer10Ml)
       .get  // Safe because validation ensures there's always a rate
 
 
-  def getDutyRate(vpdId: VpdId, periodKey: PeriodKey)
-                 (using ec: ExecutionContext, hc: HeaderCarrier): Future[BigDecimal] =
+  def getDutyRateInPoundsPerMl(vpdId: VpdId, periodKey: PeriodKey)
+                              (using ec: ExecutionContext, hc: HeaderCarrier): Future[BigDecimal] =
 
-    getDutyRateForPeriod(vpdId, periodKey).flatMap {
+    getDutyRateForPeriodInPoundsPerMl(vpdId, periodKey).flatMap {
       case Some(dutyRate) => Future.successful(dutyRate)
       case None => Future.failed(RuntimeException("No duty rate found"))
     }
 
-  def getDutyRateForPeriod(vpdId: VpdId, periodKey: PeriodKey)
-                          (using ec: ExecutionContext, hc: HeaderCarrier): Future[Option[BigDecimal]] =
+  def getDutyRateForPeriodInPoundsPerMl(vpdId: VpdId, periodKey: PeriodKey)
+                                       (using ec: ExecutionContext, hc: HeaderCarrier): Future[Option[BigDecimal]] =
 
     obligationService.getObligationByPeriodKey(vpdId, periodKey).map { obligationOpt =>
       obligationOpt.map { obligation =>
-        val rateInPencePerMl: Int = getRateForDate(obligation.iCFromDate)
-        val dutyRateInPoundsPerMl = BigDecimal(rateInPencePerMl) / 100
+        val rateInPencePerMl = BigDecimal(getRateForDateInPencePer10ml(obligation.iCFromDate)) / 10
+        val dutyRateInPoundsPerMl = rateInPencePerMl / 100
         dutyRateInPoundsPerMl
       }
     }
     
-  def getDutyRatesInPencePerMlForPeriodKeys(obligations: Seq[ObligationDetails]): Map[PeriodKey, Int] = {
-    obligations.map(o => PeriodKey(o.periodKey) -> getRateForDate(o.iCFromDate)).toMap
+  def getDutyRatesInPencePer10MlForPeriodKeys(obligations: Seq[ObligationDetails]): Map[PeriodKey, Int] = {
+    obligations.map(o => PeriodKey(o.periodKey) -> getRateForDateInPencePer10ml(o.iCFromDate)).toMap
   }
 }

--- a/app/services/returns/SubmitReturnService.scala
+++ b/app/services/returns/SubmitReturnService.scala
@@ -42,13 +42,13 @@ class SubmitReturnService @Inject()(
 
     for {
       obligations <- obligationService.getObligationsDirectly(request.enrolmentVpdId)
-      periodKeyToDutyRateInPencePerMl = dutyRateService.getDutyRatesInPencePerMlForPeriodKeys(obligations)
+      periodKeyToDutyRateInPencePer10Ml = dutyRateService.getDutyRatesInPencePer10MlForPeriodKeys(obligations)
       obligationOpt = obligations.find(_.periodKey == request.periodKey.toString)
       obligation <- obligationOpt match {
         case Some(obl) => Future.successful(obl)
         case None => Future.failed(new IllegalStateException(s"No obligation found for period key: ${ua.periodKey}"))
       }
-      submission = buildReturnSubmissionService.buildSubmission(ua, obligation, request.enrolmentVpdId, periodKeyToDutyRateInPencePerMl)
+      submission = buildReturnSubmissionService.buildSubmission(ua, obligation, request.enrolmentVpdId, periodKeyToDutyRateInPencePer10Ml)
       result <- submitReturnConnector.submitReturn(submission, request.enrolmentVpdId)
     } yield {
       auditService.auditReturnSubmitted(

--- a/app/viewmodels/checkAnswers/ReturnsSummary.scala
+++ b/app/viewmodels/checkAnswers/ReturnsSummary.scala
@@ -30,17 +30,17 @@ import viewmodels.implicits.*
 object ReturnsSummary extends CurrencyFormatter {
 
   def summaryList(
-    answers: ReturnsUserAnswers,
-    dutyRate: BigDecimal,
-    periodKey: PeriodKey
+                   answers: ReturnsUserAnswers,
+                   dutyRateInPoundsPerMl: BigDecimal,
+                   periodKey: PeriodKey
   )(implicit messages: Messages): SummaryList = {
     val rows = Seq(
       buildDeclareDutyRow(answers, periodKey),
-      buildDutyRow(answers, dutyRate, periodKey),
+      buildDutyRow(answers, dutyRateInPoundsPerMl, periodKey),
       //      buildSpoiltRow(answers, periodKey),
       //      buildOverRow(answers, periodKey),
       //      buildUnderRow(answers, periodKey),
-      buildTotalDutyRow(answers, dutyRate)
+      buildTotalDutyRow(answers, dutyRateInPoundsPerMl)
     ).flatten
 
     SummaryList(rows = rows, classes = CssConstants.marginBottom9)
@@ -76,20 +76,20 @@ object ReturnsSummary extends CurrencyFormatter {
     ))
   }
 
-  def calculateDuty(volumeInMl: BigDecimal, dutyRate: BigDecimal): BigDecimal =
-    (volumeInMl * dutyRate).setScale(2, BigDecimal.RoundingMode.DOWN)
+  def calculateDuty(volumeInMl: BigDecimal, dutyRateInPoundsPerMl: BigDecimal): BigDecimal =
+    (volumeInMl * dutyRateInPoundsPerMl).setScale(2, BigDecimal.RoundingMode.DOWN)
 
   private def buildDutyRow(
-    answers: ReturnsUserAnswers,
-    dutyRate: BigDecimal,
-    periodKey: PeriodKey
+                            answers: ReturnsUserAnswers,
+                            dutyRateInPoundsPerMl: BigDecimal,
+                            periodKey: PeriodKey
   )(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(DeclareDutyPage) match {
       case Some(true) =>
         answers.get(EnterDutyAmountPage) match {
           case Some(volumeInMl) if volumeInMl == 0 => dutyRow(messages("returns.CheckYourAnswers.dutySummary.nothing"), periodKey)
           case Some(volumeInMl) => 
-            val dutyDue = calculateDuty(volumeInMl, dutyRate)
+            val dutyDue = calculateDuty(volumeInMl, dutyRateInPoundsPerMl)
             dutyRow(currencyFormat(dutyDue), periodKey)
           case None => dutyRow(messages("returns.CheckYourAnswers.dutySummary.nothing"), periodKey)
         }
@@ -141,14 +141,14 @@ object ReturnsSummary extends CurrencyFormatter {
   }
 
   private def buildTotalDutyRow(
-    answers: ReturnsUserAnswers,
-    dutyRate: BigDecimal
+                                 answers: ReturnsUserAnswers,
+                                 dutyRateInPoundsPerMl: BigDecimal
   )(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(DeclareDutyPage) match {
       case Some(true) =>
         answers.get(EnterDutyAmountPage) match {
           case Some(volumeInMl) => 
-            val dutyDue = calculateDuty(volumeInMl, dutyRate)
+            val dutyDue = calculateDuty(volumeInMl, dutyRateInPoundsPerMl)
             totalDutyRow(currencyFormat(dutyDue))
           case None => totalDutyRow(messages("returns.CheckYourAnswers.dutySummary.total.nil"))
         }

--- a/app/viewmodels/returns/submit/CheckYourAnswersViewModel.scala
+++ b/app/viewmodels/returns/submit/CheckYourAnswersViewModel.scala
@@ -44,7 +44,7 @@ object CheckYourAnswersViewModel {
 
   private val ZERO = "0"
 
-  def apply(userAnswers: ReturnsUserAnswers, dutyRate: BigDecimal, periodKey: PeriodKey, returnsDateUtils: ReturnsDateUtils)(implicit messages: Messages): CheckYourAnswersViewModel = {
+  def apply(userAnswers: ReturnsUserAnswers, dutyRateInPoundsPer10Ml: BigDecimal, periodKey: PeriodKey, returnsDateUtils: ReturnsDateUtils)(implicit messages: Messages): CheckYourAnswersViewModel = {
     // scalafix:off DisableSyntax.throw
     val returnPeriod = userAnswers.returnPeriod
       .map(month => returnsDateUtils.getReturnMonth(month))
@@ -56,12 +56,12 @@ object CheckYourAnswersViewModel {
     val nilReturn = isNilReturn(userAnswers)
     
     CheckYourAnswersViewModel(
-      finalDutySummaryList = ReturnsSummary.summaryList(userAnswers, dutyRate, periodKey),
+      finalDutySummaryList = ReturnsSummary.summaryList(userAnswers, dutyRateInPoundsPer10Ml, periodKey),
       dutySuspendedSummaryList = DutySuspenseSummary.summaryList(userAnswers, periodKey),
-      dutyDue = dutyDue(userAnswers, dutyRate),
-      dutyRate = currencyFormat(dutyRate),
+      dutyDue = dutyDue(userAnswers, dutyRateInPoundsPer10Ml),
+      dutyRate = currencyFormat(dutyRateInPoundsPer10Ml),
       dutyRateParagraph = dutyRateParagraph(nilReturn),
-      dutyCalculationParagraph = dutyCalculationParagraph(dutyRate),
+      dutyCalculationParagraph = dutyCalculationParagraph(dutyRateInPoundsPer10Ml),
       nilReturn = nilReturn,
       returnPeriod = returnPeriod,
       year = year

--- a/app/viewmodels/returns/submit/DeclareDutyCheckAnswersViewModel.scala
+++ b/app/viewmodels/returns/submit/DeclareDutyCheckAnswersViewModel.scala
@@ -38,13 +38,13 @@ object DeclareDutyCheckAnswersViewModel {
 
   private val ML_SUFFIX = " ml"
 
-  def apply(userAnswers: ReturnsUserAnswers, dutyRate: BigDecimal, periodKey: PeriodKey)
+  def apply(userAnswers: ReturnsUserAnswers, dutyRateInPoundsPerMl: BigDecimal, periodKey: PeriodKey)
            (implicit messages: Messages): Option[DeclareDutyCheckAnswersViewModel] = {
     
     userAnswers.get(pages.returns.DeclareDutyPage).flatMap { declareDuty =>
       if (declareDuty) {
         userAnswers.get(EnterDutyAmountPage).map { volumeInMl =>
-          val dutyAmount = ReturnsSummary.calculateDuty(volumeInMl, dutyRate)
+          val dutyAmount = ReturnsSummary.calculateDuty(volumeInMl, dutyRateInPoundsPerMl)
           DeclareDutyCheckAnswersViewModel(
             heading = messages("returns.declareDutyCheckAnswers.heading", ReturnsSummary.currencyFormat(dutyAmount)),
             volumeFormatted = Some(formatVolume(volumeInMl)),

--- a/app/viewmodels/returns/submit/adjustments/AdjustmentCheckYourAnswersViewModel.scala
+++ b/app/viewmodels/returns/submit/adjustments/AdjustmentCheckYourAnswersViewModel.scala
@@ -127,7 +127,7 @@ object AdjustmentCheckYourAnswersViewModel {
 
     val rows = Seq(
       buildDeclareAdjustmentRow(currentPeriodKey, declaredAdjustment = true),
-      buildTypeRow(adjustment.adjustmentType, adjustment.period, currentPeriodKey),
+      buildTypeRow(adjustment.adjustmentType),
       buildVolumeRow(adjustment.volumeInMl, adjustment.period, currentPeriodKey),
       buildDutyRow(dutyAmount, adjustment.adjustmentType)
     )
@@ -179,8 +179,6 @@ object AdjustmentCheckYourAnswersViewModel {
 
   private def buildTypeRow(
                             adjustmentType: AdjustmentType,
-                            adjustmentPeriod: PeriodKey,
-                            currentPeriodKey: PeriodKey
                           )(implicit messages: Messages): SummaryListRow = {
     val typeText = adjustmentType match {
       case AdjustmentType.UnderDeclared => messages("returns.adjustmentCheckYourAnswers.type.underDeclared")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -155,16 +155,16 @@ duty-rates = [
   {
     start-date = "2022-01-01"
     end-date = "2027-10-31"
-    rate-pence-per-ml = 22
+    rate-pence-per-10ml = 220
   },
   {
     start-date = "2027-11-01"
     end-date = "2027-11-30"
-    rate-pence-per-ml = 30
+    rate-pence-per-10ml = 300
   },
   {
     start-date = "2027-12-01"
     end-date = "9999-12-31"
-    rate-pence-per-ml = 40
+    rate-pence-per-10ml = 400
   }
 ]

--- a/it/test/config/DutyRateConfigValidationISpec.scala
+++ b/it/test/config/DutyRateConfigValidationISpec.scala
@@ -33,7 +33,7 @@ class DutyRateConfigValidationISpec extends AnyFreeSpec with Matchers {
       dutyRateConfig.rates must not be empty
       
       dutyRateConfig.rates.foreach { rate =>
-        rate.ratePencePerMl must be > 0
+        rate.ratePencePer10Ml must be > 0
       }
       
       dutyRateConfig.rates.foreach { rate =>

--- a/test/config/DutyRateConfigSpec.scala
+++ b/test/config/DutyRateConfigSpec.scala
@@ -41,12 +41,12 @@ class DutyRateConfigSpec extends SpecBase {
           |  {
           |    start-date = "2026-01-01"
           |    end-date = "2026-12-31"
-          |    rate-pence-per-ml = 22
+          |    rate-pence-per-10ml = 220
           |  },
           |  {
           |    start-date = "2027-01-01"
           |    end-date = "9999-12-31"
-          |    rate-pence-per-ml = 30
+          |    rate-pence-per-10ml = 300
           |  }
           |]
           |""".stripMargin)), validator)
@@ -54,8 +54,8 @@ class DutyRateConfigSpec extends SpecBase {
       config.rates must have size 2
       config.rates.head.period.start mustBe LocalDate.of(2026, 1, 1)
       config.rates.head.period.end mustBe LocalDate.of(2026, 12, 31)
-      config.rates.head.ratePencePerMl mustBe 22
-      config.rates(1).ratePencePerMl mustBe 30
+      config.rates.head.ratePencePerMl mustBe 220
+      config.rates(1).ratePencePerMl mustBe 300
     }
 
 
@@ -80,19 +80,19 @@ class DutyRateConfigSpec extends SpecBase {
             |  {
             |    start-date = "2026-01-01"
             |    end-date = "2026-12-31"
-            |    rate-pence-per-ml = 22
+            |    rate-pence-per-10ml = 220
             |  },
             |  {
             |    start-date = "2027-01-01"
             |    end-date = "9999-12-31"
-            |    rate-pence-per-ml = 30
+            |    rate-pence-per-10ml = 300
             |  }
             |]
             |""".stripMargin))
 
         parseRatesFromConfig(config) mustBe Seq(
-          DutyRate(DateRange(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-12-31")), 22),
-          DutyRate(DateRange(LocalDate.parse("2027-01-01"), LocalDate.parse("9999-12-31")), 30)
+          DutyRate(DateRange(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-12-31")), 220),
+          DutyRate(DateRange(LocalDate.parse("2027-01-01"), LocalDate.parse("9999-12-31")), 300)
         )
       }
 
@@ -103,20 +103,20 @@ class DutyRateConfigSpec extends SpecBase {
             |  {
             |    start-date = "2026-01-01"
             |    end-date = "2026-11-30"
-            |    rate-pence-per-ml = 22
+            |    rate-pence-per-10ml = 220
             |  },
             |  # Gap between Nov and Feb can be read but will fail later validation checks!
             |  {
             |    start-date = "2027-02-01"
             |    end-date = "9999-12-31"
-            |    rate-pence-per-ml = 30
+            |    rate-pence-per-10ml = 300
             |  }
             |]
             |""".stripMargin))
 
         parseRatesFromConfig(config) mustBe Seq(
-          DutyRate(DateRange(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-11-30")), 22),
-          DutyRate(DateRange(LocalDate.parse("2027-02-01"), LocalDate.parse("9999-12-31")), 30)
+          DutyRate(DateRange(LocalDate.parse("2026-01-01"), LocalDate.parse("2026-11-30")), 220),
+          DutyRate(DateRange(LocalDate.parse("2027-02-01"), LocalDate.parse("9999-12-31")), 300)
         )
       }
 
@@ -128,7 +128,7 @@ class DutyRateConfigSpec extends SpecBase {
             |    start-date = "2026-01-01"
             |    # The 31st Nov does not exist! 
             |    end-date = "2026-11-31"
-            |    rate-pence-per-ml = 22
+            |    rate-pence-per-10ml = 220
             |  }
             |]
             |""".stripMargin))
@@ -140,14 +140,14 @@ class DutyRateConfigSpec extends SpecBase {
         exception.getMessage must include("Text '2026-11-31' could not be parsed: Invalid date 'NOVEMBER 31'")
       }
 
-      "will fail to parse non-integer rate-pence-per-ml" in {
+      "will fail to parse non-integer rate-pence-per-10ml" in {
         val config = Configuration(ConfigFactory.parseString(
           """
             |duty-rates = [
             |  {
             |    start-date = "2026-01-01"
             |    end-date = "2026-11-30"
-            |    rate-pence-per-ml = 22.5
+            |    rate-pence-per-10ml = 220.5
             |  }
             |]
             |""".stripMargin))
@@ -156,7 +156,7 @@ class DutyRateConfigSpec extends SpecBase {
           parseRatesFromConfig(config)
         }
 
-        exception.getMessage must include("For input string: \"22.5\"")
+        exception.getMessage must include("For input string: \"220.5\"")
       }
 
       "will fail to parse non-numeric reate-pence-per-ml" in {
@@ -166,7 +166,7 @@ class DutyRateConfigSpec extends SpecBase {
             |  {
             |    start-date = "2026-01-01"
             |    end-date = "2026-11-30"
-            |    rate-pence-per-ml = "foo-bar"
+            |    rate-pence-per-10ml = "foo-bar"
             |  }
             |]
             |""".stripMargin))
@@ -185,7 +185,7 @@ class DutyRateConfigSpec extends SpecBase {
             |  {
             |    # start-date missing!
             |    end-date = "2026-11-31"
-            |    rate-pence-per-ml = 22
+            |    rate-pence-per-10ml = 220
             |  }
             |]
             |""".stripMargin))
@@ -204,7 +204,7 @@ class DutyRateConfigSpec extends SpecBase {
             |  {
             |    start-date = "2026-01-01"
             |    # end-date missing!
-            |    rate-pence-per-ml = 22
+            |    rate-pence-per-10ml = 220
             |  }
             |]
             |""".stripMargin))
@@ -216,14 +216,14 @@ class DutyRateConfigSpec extends SpecBase {
         exception.getMessage must include("No configuration setting found for key 'end-date'")
       }
 
-      "will fail to parse if the rate-pence-per-ml is missing" in {
+      "will fail to parse if the rate-pence-per-10ml is missing" in {
         val config = Configuration(ConfigFactory.parseString(
           """
             |duty-rates = [
             |  {
             |    start-date = "2026-01-01"
             |    end-date = "2026-11-30"
-            |    # rate-pence-per-ml missing!
+            |    # rate-pence-per-10ml missing!
             |  }
             |]
             |""".stripMargin))
@@ -232,7 +232,7 @@ class DutyRateConfigSpec extends SpecBase {
           parseRatesFromConfig(config)
         }
 
-        exception.getMessage must include("No configuration setting found for key 'rate-pence-per-ml'")
+        exception.getMessage must include("No configuration setting found for key 'rate-pence-per-10ml'")
       }
     }
 

--- a/test/config/DutyRateConfigSpec.scala
+++ b/test/config/DutyRateConfigSpec.scala
@@ -54,8 +54,8 @@ class DutyRateConfigSpec extends SpecBase {
       config.rates must have size 2
       config.rates.head.period.start mustBe LocalDate.of(2026, 1, 1)
       config.rates.head.period.end mustBe LocalDate.of(2026, 12, 31)
-      config.rates.head.ratePencePerMl mustBe 220
-      config.rates(1).ratePencePerMl mustBe 300
+      config.rates.head.ratePencePer10Ml mustBe 220
+      config.rates(1).ratePencePer10Ml mustBe 300
     }
 
 

--- a/test/config/DutyRateValidatorSpec.scala
+++ b/test/config/DutyRateValidatorSpec.scala
@@ -31,7 +31,7 @@ class DutyRateValidatorSpec extends SpecBase {
       start = LocalDate.of(2026, 1, 1),
       end = LocalDate.of(2026, 12, 31)
     ),
-    ratePencePerMl = 22
+    ratePencePer10Ml = 220
   )
 
   private val validRate2 = DutyRate(
@@ -39,7 +39,7 @@ class DutyRateValidatorSpec extends SpecBase {
       start = LocalDate.of(2027, 1, 1),
       end = LocalDate.of(9999, 12, 31)
     ),
-    ratePencePerMl = 30
+    ratePencePer10Ml = 300
   )
 
   "validateNonEmpty" - {
@@ -72,7 +72,7 @@ class DutyRateValidatorSpec extends SpecBase {
     }
 
     "must return Left(NegativeRate) when a rate is zero" in {
-      val zeroRate = validRate1.copy(ratePencePerMl = 0)
+      val zeroRate = validRate1.copy(ratePencePer10Ml = 0)
       val rates = Seq(zeroRate)
 
       val result = validator.validatePositiveRates(rates)
@@ -81,7 +81,7 @@ class DutyRateValidatorSpec extends SpecBase {
     }
 
     "must return Left(NegativeRate) when a rate is negative" in {
-      val negativeRate = validRate1.copy(ratePencePerMl = -10)
+      val negativeRate = validRate1.copy(ratePencePer10Ml = -100)
       val rates = Seq(negativeRate)
 
       val result = validator.validatePositiveRates(rates)
@@ -90,8 +90,8 @@ class DutyRateValidatorSpec extends SpecBase {
     }
 
     "must return Left with all invalid rates when multiple rates are invalid" in {
-      val zeroRate = validRate1.copy(ratePencePerMl = 0)
-      val negativeRate = validRate2.copy(ratePencePerMl = -5)
+      val zeroRate = validRate1.copy(ratePencePer10Ml = 0)
+      val negativeRate = validRate2.copy(ratePencePer10Ml = -50)
       val rates = Seq(zeroRate, negativeRate)
 
       val result = validator.validatePositiveRates(rates)
@@ -261,7 +261,7 @@ class DutyRateValidatorSpec extends SpecBase {
           start = today.minusDays(10),
           end = today.plusDays(10)
         ),
-        ratePencePerMl = -5
+        ratePencePer10Ml = -50
       )
       val rates = Seq(invalidRate)
 
@@ -277,7 +277,7 @@ class DutyRateValidatorSpec extends SpecBase {
           start = today.plusDays(10),
           end = today.minusDays(10)
         ),
-        ratePencePerMl = 25
+        ratePencePer10Ml = 250
       )
       val rates = Seq(invalidRate)
 
@@ -332,7 +332,7 @@ class DutyRateValidatorSpec extends SpecBase {
           start = LocalDate.of(2026, 6, 1),
           end = LocalDate.of(2026, 6, 10)
         ),
-        ratePencePerMl = -5
+        ratePencePer10Ml = -50
       )
 
       val rate2 = validRate2.copy(
@@ -340,7 +340,7 @@ class DutyRateValidatorSpec extends SpecBase {
           start = LocalDate.of(2026, 6, 15),
           end = LocalDate.of(2026, 6, 12)
         ),
-        ratePencePerMl = 10
+        ratePencePer10Ml = 100
       )
 
       val rates = Seq(rate1, rate2)

--- a/test/controllers/returns/submit/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/returns/submit/CheckYourAnswersControllerSpec.scala
@@ -38,7 +38,7 @@ class CheckYourAnswersControllerSpec extends SpecBase {
 
       val mockDutyRateService = mock[DutyRateService]
 
-      when(mockDutyRateService.getDutyRate(any(), any())(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(any(), any())(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
 
       val application = applicationBuilder(returnsUserAnswers = Some(returnsUserAnswers))
@@ -63,7 +63,7 @@ class CheckYourAnswersControllerSpec extends SpecBase {
 
       val mockDutyRateService = mock[DutyRateService]
 
-      when(mockDutyRateService.getDutyRate(any(), any())(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(any(), any())(using any(), any()))
         .thenReturn(Future.failed(RuntimeException("No duty rate found")))
 
       val application = applicationBuilder(returnsUserAnswers = Some(returnsUserAnswers))

--- a/test/controllers/returns/submit/DeclareDutyCheckAnswersControllerSpec.scala
+++ b/test/controllers/returns/submit/DeclareDutyCheckAnswersControllerSpec.scala
@@ -40,7 +40,7 @@ class DeclareDutyCheckAnswersControllerSpec extends SpecBase {
 
       val mockDutyRateService = mock[DutyRateService]
 
-      when(mockDutyRateService.getDutyRate(any(), any())(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(any(), any())(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
 
       val application = applicationBuilder(returnsUserAnswers = Some(ua))
@@ -64,7 +64,7 @@ class DeclareDutyCheckAnswersControllerSpec extends SpecBase {
 
       val mockDutyRateService = mock[DutyRateService]
 
-      when(mockDutyRateService.getDutyRate(any(), any())(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(any(), any())(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
 
       val application = applicationBuilder(returnsUserAnswers = Some(returnsUserAnswers))
@@ -85,7 +85,7 @@ class DeclareDutyCheckAnswersControllerSpec extends SpecBase {
 
       val mockDutyRateService = mock[DutyRateService]
 
-      when(mockDutyRateService.getDutyRate(any(), any())(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(any(), any())(using any(), any()))
         .thenReturn(Future.failed(RuntimeException("No duty rate found")))
 
       val application = applicationBuilder(returnsUserAnswers = Some(returnsUserAnswers))

--- a/test/forms/returns/EnterDutyAmountFormProviderSpec.scala
+++ b/test/forms/returns/EnterDutyAmountFormProviderSpec.scala
@@ -44,7 +44,7 @@ class EnterDutyAmountFormProviderSpec extends SpecBase with MockitoSugar {
     val fieldName = "value"
 
     "must bind valid values >= 1000ml with no decimal places" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -58,7 +58,7 @@ class EnterDutyAmountFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must bind valid values < 1000ml with 0 or 1 decimal place" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -72,7 +72,7 @@ class EnterDutyAmountFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind empty values" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -84,7 +84,7 @@ class EnterDutyAmountFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind non-numeric values" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -98,7 +98,7 @@ class EnterDutyAmountFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind zero" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -110,7 +110,7 @@ class EnterDutyAmountFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must bind values >= 1000ml with trailing zeros" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -124,7 +124,7 @@ class EnterDutyAmountFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind values >= 1000ml with non-zero decimal places" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -138,7 +138,7 @@ class EnterDutyAmountFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind values < 1000ml with more than 1 decimal place" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -152,7 +152,7 @@ class EnterDutyAmountFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind values that exceed the calculated maximum" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(337))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))

--- a/test/forms/returns/EnterDutySuspenseFormProviderSpec.scala
+++ b/test/forms/returns/EnterDutySuspenseFormProviderSpec.scala
@@ -40,7 +40,7 @@ class EnterDutySuspenseFormProviderSpec extends SpecBase with MockitoSugar {
   private val testFormattedMax = "29,000,000,000 ml"
 
   private def setupMocks(): Unit = {
-    when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+    when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
       .thenReturn(Future.successful(testDutyRate))
     when(mockVolumePrecisionService.calculateMaxVolume(any()))
       .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -139,7 +139,7 @@ class EnterDutySuspenseFormProviderSpec extends SpecBase with MockitoSugar {
       }
 
       "must fail to bind values that exceed the calculated maximum" in {
-        when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+        when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
           .thenReturn(Future.successful(testDutyRate))
         when(mockVolumePrecisionService.calculateMaxVolume(337))
           .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -244,7 +244,7 @@ class EnterDutySuspenseFormProviderSpec extends SpecBase with MockitoSugar {
       }
 
       "must fail to bind values that exceed the calculated maximum" in {
-        when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+        when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
           .thenReturn(Future.successful(testDutyRate))
         when(mockVolumePrecisionService.calculateMaxVolume(337))
           .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))

--- a/test/forms/returns/SpoiltVolumeByPeriodFormProviderSpec.scala
+++ b/test/forms/returns/SpoiltVolumeByPeriodFormProviderSpec.scala
@@ -44,7 +44,7 @@ class SpoiltVolumeByPeriodFormProviderSpec extends SpecBase with MockitoSugar {
     val fieldName = "value"
 
     "must bind valid values >= 1000ml with no decimal places" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -58,7 +58,7 @@ class SpoiltVolumeByPeriodFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must bind valid values < 1000ml with 0 or 1 decimal place" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -72,7 +72,7 @@ class SpoiltVolumeByPeriodFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind empty values" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -84,7 +84,7 @@ class SpoiltVolumeByPeriodFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind non-numeric values" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -98,7 +98,7 @@ class SpoiltVolumeByPeriodFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind zero" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -110,7 +110,7 @@ class SpoiltVolumeByPeriodFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must bind values >= 1000ml with trailing zeros" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -124,7 +124,7 @@ class SpoiltVolumeByPeriodFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind values >= 1000ml with non-zero decimal places" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -138,7 +138,7 @@ class SpoiltVolumeByPeriodFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind values < 1000ml with more than 1 decimal place" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(any()))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))
@@ -152,7 +152,7 @@ class SpoiltVolumeByPeriodFormProviderSpec extends SpecBase with MockitoSugar {
     }
 
     "must not bind values that exceed the calculated maximum" in {
-      when(mockDutyRateService.getDutyRate(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
+      when(mockDutyRateService.getDutyRateInPoundsPerMl(eqTo(testVpdId), eqTo(testPeriodKey))(using any(), any()))
         .thenReturn(Future.successful(testDutyRate))
       when(mockVolumePrecisionService.calculateMaxVolume(337))
         .thenReturn(MaxVolumeResult(testMaxVolume, testFormattedMax))

--- a/test/services/returns/AdjustmentCheckYourAnswersServiceSpec.scala
+++ b/test/services/returns/AdjustmentCheckYourAnswersServiceSpec.scala
@@ -50,7 +50,7 @@ class AdjustmentCheckYourAnswersServiceSpec extends SpecBase with MockitoSugar w
     openObligation(periodKey)
   )
 
-  private val DUTY_RATE_PENCE = 100
+  private val DUTY_RATE_PENCE_PER_10ML = 1000
 
   implicit val messages: Messages = stubMessages()
 
@@ -68,8 +68,8 @@ class AdjustmentCheckYourAnswersServiceSpec extends SpecBase with MockitoSugar w
 
       when(mockObligationService.getObligationsDirectly(eqTo(vpdId))(using any()))
         .thenReturn(Future.successful(Seq(obligationForAdjustment)))
-      when(mockDutyRateService.getRateForDate(any()))
-        .thenReturn(DUTY_RATE_PENCE)
+      when(mockDutyRateService.getRateForDateInPencePer10ml(any()))
+        .thenReturn(DUTY_RATE_PENCE_PER_10ML)
 
       val result = service.buildViewModel(
         declareAdjustment = Some(true),
@@ -119,8 +119,8 @@ class AdjustmentCheckYourAnswersServiceSpec extends SpecBase with MockitoSugar w
 
       when(mockObligationService.getObligationsDirectly(eqTo(vpdId))(using any()))
         .thenReturn(Future.successful(Seq(obligationForAdjustment1, obligationForAdjustment2)))
-      when(mockDutyRateService.getRateForDate(any()))
-        .thenReturn(DUTY_RATE_PENCE)
+      when(mockDutyRateService.getRateForDateInPencePer10ml(any()))
+        .thenReturn(DUTY_RATE_PENCE_PER_10ML)
 
       val result = service.buildViewModel(
         declareAdjustment = Some(true),

--- a/test/services/returns/BuildReturnSubmissionServiceSpec.scala
+++ b/test/services/returns/BuildReturnSubmissionServiceSpec.scala
@@ -79,7 +79,7 @@ class BuildReturnSubmissionServiceSpec extends SpecBase with MockitoSugar with B
           .set(EnterDutyAmountPage, BigDecimal("1000")).success.value
           .set(DeclarationPage, declaration).success.value
 
-        val returnCreateRequest = service.buildSubmission(userAnswers, obligation, vpdId, Map(PeriodKey(obligation.periodKey) -> 1050))
+        val returnCreateRequest = service.buildSubmission(userAnswers, obligation, vpdId, Map(PeriodKey(obligation.periodKey) -> 10500))
         
         returnCreateRequest.vapingProductsProduced.vapingProdManufactured mustBe yes
         returnCreateRequest.vapingProductsProduced.returns.size mustBe 1
@@ -144,7 +144,7 @@ class BuildReturnSubmissionServiceSpec extends SpecBase with MockitoSugar with B
           .set(SpoiltVolumeByPeriodPage, spoiltVolumes).success.value
           .set(DeclarationPage, declaration).success.value
 
-        val returnCreateRequest = service.buildSubmission(userAnswers, openObligation(december2026), vpdId, Map(october2026 -> 1050, november2026 -> 1050, december2026 -> 1050))
+        val returnCreateRequest = service.buildSubmission(userAnswers, openObligation(december2026), vpdId, Map(october2026 -> 10500, november2026 -> 10500, december2026 -> 10500))
 
         returnCreateRequest.vapingProductsProduced.vapingProdManufactured mustBe yes
         returnCreateRequest.vapingProductsProduced.returns.size mustBe 1
@@ -178,7 +178,7 @@ class BuildReturnSubmissionServiceSpec extends SpecBase with MockitoSugar with B
           .set(EnterDutySuspensePage, dutySuspenseVolumes).success.value
           .set(DeclarationPage, declaration).success.value
 
-        val returnCreateRequest = service.buildSubmission(userAnswers, obligation, vpdId, Map(PeriodKey(obligation.periodKey) -> 1050))
+        val returnCreateRequest = service.buildSubmission(userAnswers, obligation, vpdId, Map(PeriodKey(obligation.periodKey) -> 10500))
 
         returnCreateRequest.vapingProductsProduced.vapingProdManufactured mustBe yes
         returnCreateRequest.vapingProductsProduced.returns.size mustBe 1
@@ -215,7 +215,7 @@ class BuildReturnSubmissionServiceSpec extends SpecBase with MockitoSugar with B
           .set(AdjustmentReasonPage, "a reason").success.value
           .set(DeclarationPage, declaration).success.value
 
-        val returnCreateRequest = service.buildSubmission(userAnswers, obligation, vpdId, Map(periodKey -> 100))
+        val returnCreateRequest = service.buildSubmission(userAnswers, obligation, vpdId, Map(periodKey -> 1000))
 
         returnCreateRequest.underDeclaration.get.underDeclFilled mustBe yes
         returnCreateRequest.underDeclaration.get.reasonForUnderDecl mustBe Some("a reason")
@@ -234,7 +234,7 @@ class BuildReturnSubmissionServiceSpec extends SpecBase with MockitoSugar with B
           .set(AdjustmentReasonPage, "a reason").success.value
           .set(DeclarationPage, declaration).success.value
 
-        val returnCreateRequest = service.buildSubmission(userAnswers, obligation, vpdId, Map(periodKey -> 100))
+        val returnCreateRequest = service.buildSubmission(userAnswers, obligation, vpdId, Map(periodKey -> 1000))
 
         returnCreateRequest.underDeclaration.get.reasonForUnderDecl mustBe Some("a reason")
         returnCreateRequest.overDeclaration.get.reasonForOverDecl mustBe Some("a reason")

--- a/test/services/returns/DutyRateServiceSpec.scala
+++ b/test/services/returns/DutyRateServiceSpec.scala
@@ -75,7 +75,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
         val date = LocalDate.of(2026, 6, 15)
-        val result = service.getRateForDate(date)
+        val result = service.getRateForDateInPencePer10ml(date)
         
         result mustBe 220
       }
@@ -85,7 +85,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
         val date = LocalDate.of(2027, 8, 20)
-        val result = service.getRateForDate(date)
+        val result = service.getRateForDateInPencePer10ml(date)
         
         result mustBe 300
       }
@@ -95,7 +95,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
         val date = LocalDate.of(2028, 3, 10)
-        val result = service.getRateForDate(date)
+        val result = service.getRateForDateInPencePer10ml(date)
         
         result mustBe 400
       }
@@ -105,7 +105,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
         val date = LocalDate.of(2027, 1, 1)
-        val result = service.getRateForDate(date)
+        val result = service.getRateForDateInPencePer10ml(date)
         
         result mustBe 300
       }
@@ -115,7 +115,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
         val date = LocalDate.of(2026, 12, 31)
-        val result = service.getRateForDate(date)
+        val result = service.getRateForDateInPencePer10ml(date)
         
         result mustBe 220
       }
@@ -125,7 +125,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
         val date = LocalDate.of(3000, 1, 1)
-        val result = service.getRateForDate(date)
+        val result = service.getRateForDateInPencePer10ml(date)
         
         result mustBe 400
       }
@@ -140,8 +140,8 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
-        whenReady(service.getDutyRateForPeriod(vpdId, PeriodKey("26AA"))) { result =>
-          result mustBe Some(BigDecimal("2.20"))
+        whenReady(service.getDutyRateForPeriodInPoundsPerMl(vpdId, PeriodKey("26AA"))) { result =>
+          result mustBe Some(BigDecimal("0.22"))
         }
       }
 
@@ -151,7 +151,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
-        whenReady(service.getDutyRateForPeriod(vpdId, PeriodKey("26XX"))) { result =>
+        whenReady(service.getDutyRateForPeriodInPoundsPerMl(vpdId, PeriodKey("26XX"))) { result =>
           result mustBe None
         }
       }
@@ -160,16 +160,14 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
     "getDutyRate" - {
 
       "must return the duty rate when obligation exists" in {
-        val expectedDutyRate = BigDecimal("2.20")
-        
         when(mockDutyRateConfig.rates).thenReturn(testRates)
         when(mockObligationService.getObligationByPeriodKey(eqTo(vpdId), eqTo(periodKey))(using any()))
           .thenReturn(Future.successful(Some(testObligation)))
         
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
-        whenReady(service.getDutyRate(vpdId, periodKey)) { result =>
-          result mustBe expectedDutyRate
+        whenReady(service.getDutyRateInPoundsPerMl(vpdId, periodKey)) { result =>
+          result mustBe BigDecimal("0.22")
         }
       }
 
@@ -180,7 +178,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
-        whenReady(service.getDutyRate(vpdId, periodKey).failed) { exception =>
+        whenReady(service.getDutyRateInPoundsPerMl(vpdId, periodKey).failed) { exception =>
           exception mustBe a[RuntimeException]
           exception.getMessage mustBe "No duty rate found"
         }

--- a/test/services/returns/DutyRateServiceSpec.scala
+++ b/test/services/returns/DutyRateServiceSpec.scala
@@ -39,21 +39,21 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         start = LocalDate.of(2026, 1, 1),
         end = LocalDate.of(2026, 12, 31)
       ),
-      ratePencePerMl = 22
+      ratePencePer10Ml = 220
     ),
     DutyRate(
       period = models.returns.DateRange(
         start = LocalDate.of(2027, 1, 1),
         end = LocalDate.of(2027, 12, 31)
       ),
-      ratePencePerMl = 30
+      ratePencePer10Ml = 300
     ),
     DutyRate(
       period = models.returns.DateRange(
         start = LocalDate.of(2028, 1, 1),
         end = LocalDate.of(9999, 12, 31)
       ),
-      ratePencePerMl = 40
+      ratePencePer10Ml = 400
     )
   )
 
@@ -77,7 +77,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val date = LocalDate.of(2026, 6, 15)
         val result = service.getRateForDate(date)
         
-        result mustBe 22
+        result mustBe 220
       }
 
       "must return the correct rate for a date within the second period" in {
@@ -87,7 +87,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val date = LocalDate.of(2027, 8, 20)
         val result = service.getRateForDate(date)
         
-        result mustBe 30
+        result mustBe 300
       }
 
       "must return the correct rate for a date within the third period" in {
@@ -97,7 +97,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val date = LocalDate.of(2028, 3, 10)
         val result = service.getRateForDate(date)
         
-        result mustBe 40
+        result mustBe 400
       }
 
       "must return the correct rate for a date on the start boundary" in {
@@ -107,7 +107,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val date = LocalDate.of(2027, 1, 1)
         val result = service.getRateForDate(date)
         
-        result mustBe 30
+        result mustBe 300
       }
 
       "must return the correct rate for a date on the end boundary" in {
@@ -117,7 +117,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val date = LocalDate.of(2026, 12, 31)
         val result = service.getRateForDate(date)
         
-        result mustBe 22
+        result mustBe 220
       }
 
       "must return the correct rate for a far future date" in {
@@ -127,7 +127,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val date = LocalDate.of(3000, 1, 1)
         val result = service.getRateForDate(date)
         
-        result mustBe 40
+        result mustBe 400
       }
     }
 
@@ -141,7 +141,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
         val service = new DutyRateService(mockDutyRateConfig, mockObligationService)
         
         whenReady(service.getDutyRateForPeriod(vpdId, PeriodKey("26AA"))) { result =>
-          result mustBe Some(BigDecimal("0.22"))
+          result mustBe Some(BigDecimal("2.20"))
         }
       }
 
@@ -160,7 +160,7 @@ class DutyRateServiceSpec extends SpecBase with MockitoSugar {
     "getDutyRate" - {
 
       "must return the duty rate when obligation exists" in {
-        val expectedDutyRate = BigDecimal("0.22")
+        val expectedDutyRate = BigDecimal("2.20")
         
         when(mockDutyRateConfig.rates).thenReturn(testRates)
         when(mockObligationService.getObligationByPeriodKey(eqTo(vpdId), eqTo(periodKey))(using any()))

--- a/test/services/returns/SubmitReturnServiceSpec.scala
+++ b/test/services/returns/SubmitReturnServiceSpec.scala
@@ -95,7 +95,7 @@ class SubmitReturnServiceSpec extends SpecBase with MockitoSugar with BeforeAndA
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    when(mockDutyRateService.getDutyRatesInPencePerMlForPeriodKeys(Seq(obligation)))
+    when(mockDutyRateService.getDutyRatesInPencePer10MlForPeriodKeys(Seq(obligation)))
       .thenReturn(Map(PeriodKey(obligation.periodKey) -> dutyRateInPence))
     reset(mockAuditService)
     reset(mockSubmitReturnConnector)


### PR DESCRIPTION
Change the duty rate configuration to be in pence-per-10ml instead of pence-per-ml. This allows duty rates to be specified to the full resolution described in the Return Data Items v2.11.